### PR TITLE
chore: pin dependencies to immutable SHAs via ghat

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
     hooks:
       - id: markdownlint
   - repo: https://github.com/jameswoolfenden/pre-commit
-    rev: ba5c36a3150a4184f9ee362a5cf11611ee9ae185 # v0.1.52
+    rev: e022e4ac6ed682e95d1e813ee62d4fece371014b # v0.1.53
     hooks:
       - id: terraform-fmt
       - id: tf2docs

--- a/example/exampleb/module.ca.tf
+++ b/example/exampleb/module.ca.tf
@@ -1,5 +1,5 @@
 module "ca" {
-  source = "git::https://github.com/JamesWoolfenden/terraform-aws-certificate-authority.git?ref=ac7e4b8f846704fa5655bcc3d4bdb6640f070f42" #ac7e4b8f846704fa5655bcc3d4bdb6640f070f42
+  source = "git::https://github.com/JamesWoolfenden/terraform-aws-certificate-authority.git?ref=c7cd5e15bf5345c0be6252cc7cb1414a2f89ff2b" #v0.2.72
   algorithm = var.algorithm
   subject   = var.subject
 }


### PR DESCRIPTION
Automated dependency pinning by [ghat](https://github.com/JamesWoolfenden/ghat).

Pins GitHub Actions, pre-commit hooks, Terraform modules/providers, Dockerfiles, and Kubernetes images to SHA digests.